### PR TITLE
feat: add Makefile.python template for Python projects with Docker Compose

### DIFF
--- a/Makefile.python
+++ b/Makefile.python
@@ -1,0 +1,152 @@
+# Makefile.python
+# Python project Makefile template with Docker Compose support
+# chrysa ecosystem standard — Python 3.14 target
+#
+# Copy to your project root as `Makefile` and update the variables below.
+
+DOCKER_IMAGE    ?= your-project-image
+PROJECT_NAME    ?= your-project
+SOURCE_DIR      ?= src
+TESTS_DIR       ?= tests
+REPORTS_DIR     := reports
+PYTHON          := python3
+DC              := docker compose
+DC_RUN          := $(DC) run --rm app
+
+# ──────────────────────────────────────────────────────────────────────────────
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?##"}; {printf "  %-25s %s\n", $$1, $$2}'
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Setup & Install
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: install
+install: ## Install project dependencies (local)
+	$(PYTHON) -m pip install -e ".[tests,lint]"
+
+.PHONY: install-dev
+install-dev: ## Install all dev dependencies (local)
+	$(PYTHON) -m pip install -e ".[tests,lint,dev]"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Build
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: build
+build: ## Build Docker image (no cache)
+	$(DC) build --no-cache
+
+.PHONY: build-cache
+build-cache: ## Build Docker image (with cache)
+	$(DC) build
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Clean
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: clean
+clean: ## Remove build artifacts and caches
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".mypy_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	rm -rf build/ dist/ $(REPORTS_DIR)/
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Lint & Format
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: lint
+lint: ## Run ruff check (linter)
+	$(DC_RUN) ruff check $(SOURCE_DIR) $(TESTS_DIR)
+
+.PHONY: format
+format: ## Run ruff format (formatter)
+	$(DC_RUN) ruff format $(SOURCE_DIR) $(TESTS_DIR)
+
+.PHONY: typecheck
+typecheck: ## Run mypy type checking
+	$(DC_RUN) mypy $(SOURCE_DIR)
+
+.PHONY: lint-all
+lint-all: lint typecheck ## Run all lint and type checks
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────────
+$(REPORTS_DIR):
+	mkdir -p $(REPORTS_DIR)
+
+.PHONY: test
+test: $(REPORTS_DIR) ## Run tests with coverage (in Docker)
+	$(DC_RUN) pytest $(TESTS_DIR) \
+		--cov=$(SOURCE_DIR) \
+		--cov-report=term-missing \
+		--cov-report=xml:$(REPORTS_DIR)/coverage.xml \
+		--junitxml=$(REPORTS_DIR)/test-results.xml \
+		-v
+
+.PHONY: test-local
+test-local: $(REPORTS_DIR) ## Run tests locally (no Docker)
+	pytest $(TESTS_DIR) \
+		--cov=$(SOURCE_DIR) \
+		--cov-report=term-missing \
+		--cov-report=xml:$(REPORTS_DIR)/coverage.xml \
+		-v
+
+.PHONY: test-fast
+test-fast: ## Run tests without coverage (fast)
+	$(DC_RUN) pytest $(TESTS_DIR) -v
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pre-commit
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: pre-commit
+pre-commit: ## Run pre-commit hooks on all files
+	pre-commit run --all-files
+
+.PHONY: pre-commit-update
+pre-commit-update: ## Update pre-commit hooks to latest versions
+	pre-commit autoupdate --bleeding-edge
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Docker Compose helpers
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: up
+up: ## Start all services (detached)
+	$(DC) up -d
+
+.PHONY: down
+down: ## Stop all services
+	$(DC) down
+
+.PHONY: logs
+logs: ## Tail service logs
+	$(DC) logs -f
+
+.PHONY: shell
+shell: ## Open a shell in the app container
+	$(DC_RUN) /bin/bash
+
+.PHONY: ps
+ps: ## Show running containers
+	$(DC) ps
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CI targets (run without Docker Compose in CI runners)
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: ci-lint
+ci-lint: ## CI: run ruff check
+	ruff check $(SOURCE_DIR) $(TESTS_DIR)
+
+.PHONY: ci-test
+ci-test: $(REPORTS_DIR) ## CI: run pytest with coverage
+	pytest $(TESTS_DIR) \
+		--cov=$(SOURCE_DIR) \
+		--cov-report=xml:$(REPORTS_DIR)/coverage.xml \
+		--junitxml=$(REPORTS_DIR)/test-results.xml
+
+.PHONY: ci
+ci: ci-lint ci-test ## CI: run all checks


### PR DESCRIPTION
## Summary

Adds `Makefile.python` — a Python-oriented Makefile template with Docker Compose support.

## Targets

- `install` / `install-dev` — pip install with extras
- `build` / `build-cache` — docker compose build
- `clean` — removes eggs, caches, build artefacts
- `lint` / `format` / `typecheck` — ruff + mypy in Docker
- `test` / `test-local` / `test-fast` — pytest with coverage
- `pre-commit` / `pre-commit-update`
- Docker helpers: `up`, `down`, `logs`, `shell`, `ps`
- CI targets: `ci-lint`, `ci-test`, `ci`

Closes #9