### PR TITLE
feat: add drift-checked docs targets to Makefile.python

### DIFF
--- a/Makefile.python
+++ b/Makefile.python
@@ -150,3 +150,32 @@ ci-test: $(REPORTS_DIR) ## CI: run pytest with coverage
 
 .PHONY: ci
 ci: ci-lint ci-test ## CI: run all checks
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Docs (drift-checked)
+# ──────────────────────────────────────────────────────────────────────────────
+# Generated docs are build artifacts: regenerate them mechanically, then fail if
+# the committed copy drifts. The CI composite action
+# (chrysa/github-actions/doc-drift) and the pre-commit `docs-drift-gate` hook
+# rely on these target names. Fill in `docs-code` (and optionally
+# `docs-screenshots`) with this project's generators — keep them deterministic
+# (sorted output, pinned hashes) so the diff stays quiet.
+DOCS_PATHS ?= docs/
+
+.PHONY: docs-code
+docs-code: ## Regenerate code-derived docs — TODO: add this project's generators
+	@echo "TODO: implement 'docs-code' to write deterministic docs under $(DOCS_PATHS)" >&2
+	@exit 1
+
+.PHONY: docs
+docs: docs-code ## Regenerate every generated doc (add screenshot deps as needed)
+
+.PHONY: docs-code-check
+docs-code-check: docs-code ## Fail if code-derived docs drift (pre-commit pre-push)
+	@git diff --exit-code -- $(DOCS_PATHS) \
+		|| { echo "Code-derived docs are stale — run 'make docs-code' and commit." >&2; exit 1; }
+
+.PHONY: docs-check
+docs-check: docs ## Fail if any generated doc drifts (CI)
+	@git diff --exit-code -- $(DOCS_PATHS) \
+		|| { echo "Generated docs are stale — run 'make docs' and commit." >&2; exit 1; }


### PR DESCRIPTION
## Why
Generalizes the doc-drift pattern piloted in chrysa/sport-intelligence-hub#80. Standardises the make target names that the CI composite action and the pre-commit hook depend on, so a new repo gets the drift-check skeleton for free.

## What
New "Docs (drift-checked)" section in `Makefile.python`:
- `DOCS_PATHS ?= docs/`
- `docs-code` — TODO stub each project fills with deterministic generators (OpenAPI/GraphQL/DB schema dumps, etc.).
- `docs` — aggregate (add `docs-screenshots` deps as needed).
- `docs-code-check` — regenerate + `git diff` (pre-commit pre-push).
- `docs-check` — regenerate everything + `git diff` (CI).

Contract: keep generators deterministic (sorted output, pinned hashes) so the diff stays quiet.

## Related
- Pilot: chrysa/sport-intelligence-hub#80
- CI action: chrysa/github-actions#105
- Shared hook: chrysa/pre-commit-tools#196

🤖 Generated with [Claude Code](https://claude.com/claude-code)