### PR TITLE
feat(templates): make all Makefile templates pass the §1 makefile-check gate

### DIFF
--- a/Makefile.basic
+++ b/Makefile.basic
@@ -1,4 +1,5 @@
 #!make
+# makefile-tier: infra   # set for your repo: lib | python-app | fullstack | infra
 ifneq (,)
 	$(error This Makefile requires GNU Make)
 endif
@@ -42,3 +43,38 @@ help: ## Display this help message
 	@echo "  PROJECT_NAME=$(PROJECT_NAME)"
 	@echo ""
 	@echo "==================================================================="
+
+# ─── Standard targets (shared-standards EXECUTION_STANDARD.md §1) ──────────────
+# Stubs so a fresh scaffold passes `makefile-check`. Replace each TODO with the
+# real command for your stack (npm, cargo, go, helm…). Covers the lib + infra
+# tiers; for python-app / fullstack use Makefile.python / Makefile.with-sub-folder.
+
+install: ## Install dependencies
+	@echo "TODO: install dependencies"
+
+lint: ## Run linter
+	@echo "TODO: run linter"
+
+format: ## Auto-format code
+	@echo "TODO: format code"
+
+typecheck: ## Run static type checker
+	@echo "TODO: typecheck"
+
+test: ## Run unit tests
+	@echo "TODO: run tests"
+
+test-cov: ## Run tests with coverage (writes coverage.xml)
+	@echo "TODO: run tests with coverage"
+
+build: ## Build production artefact
+	@echo "TODO: build"
+
+dev: ## Start dev server / watch mode
+	@echo "TODO: dev"
+
+clean: ## Remove generated artefacts and caches
+	@echo "TODO: clean"
+
+pre-commit: ## Run pre-commit hooks on all files
+	@pre-commit run --all-files

--- a/Makefile.python
+++ b/Makefile.python
@@ -1,8 +1,12 @@
+# makefile-tier: python-app
 # Makefile.python
 # Python project Makefile template with Docker Compose support
 # chrysa ecosystem standard — Python 3.14 target
+# Conforms to shared-standards EXECUTION_STANDARD.md §1 (python-app tier).
 #
 # Copy to your project root as `Makefile` and update the variables below.
+# For a pure library with no docker-compose.yml, use the `lib` tier instead
+# (reference: chrysa/django-pytest/Makefile).
 
 DOCKER_IMAGE    ?= your-project-image
 PROJECT_NAME    ?= your-project
@@ -31,6 +35,13 @@ install: ## Install project dependencies (local)
 .PHONY: install-dev
 install-dev: ## Install all dev dependencies (local)
 	$(PYTHON) -m pip install -e ".[tests,lint,dev]"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Dev
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: dev
+dev: ## Start the dev stack with hot-reload (Ctrl+C to stop)
+	$(DC) up --build
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Build
@@ -80,7 +91,11 @@ $(REPORTS_DIR):
 	mkdir -p $(REPORTS_DIR)
 
 .PHONY: test
-test: $(REPORTS_DIR) ## Run tests with coverage (in Docker)
+test: ## Run unit tests in Docker (fast, no coverage)
+	$(DC_RUN) pytest $(TESTS_DIR) -v
+
+.PHONY: test-cov
+test-cov: $(REPORTS_DIR) ## Run tests with coverage in Docker (writes coverage.xml)
 	$(DC_RUN) pytest $(TESTS_DIR) \
 		--cov=$(SOURCE_DIR) \
 		--cov-report=term-missing \
@@ -88,17 +103,16 @@ test: $(REPORTS_DIR) ## Run tests with coverage (in Docker)
 		--junitxml=$(REPORTS_DIR)/test-results.xml \
 		-v
 
+.PHONY: docker-test
+docker-test: test-cov ## Run the CI-compatible test suite in Docker (alias for test-cov)
+
 .PHONY: test-local
-test-local: $(REPORTS_DIR) ## Run tests locally (no Docker)
+test-local: $(REPORTS_DIR) ## Run tests locally without Docker (IDE convenience only)
 	pytest $(TESTS_DIR) \
 		--cov=$(SOURCE_DIR) \
 		--cov-report=term-missing \
 		--cov-report=xml:$(REPORTS_DIR)/coverage.xml \
 		-v
-
-.PHONY: test-fast
-test-fast: ## Run tests without coverage (fast)
-	$(DC_RUN) pytest $(TESTS_DIR) -v
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Pre-commit
@@ -114,12 +128,12 @@ pre-commit-update: ## Update pre-commit hooks to latest versions
 # ──────────────────────────────────────────────────────────────────────────────
 # Docker Compose helpers
 # ──────────────────────────────────────────────────────────────────────────────
-.PHONY: up
-up: ## Start all services (detached)
+.PHONY: docker-up
+docker-up: ## Start all services (detached)
 	$(DC) up -d
 
-.PHONY: down
-down: ## Stop all services
+.PHONY: docker-down
+docker-down: ## Stop all services
 	$(DC) down
 
 .PHONY: logs
@@ -150,6 +164,17 @@ ci-test: $(REPORTS_DIR) ## CI: run pytest with coverage
 
 .PHONY: ci
 ci: ci-lint ci-test ## CI: run all checks
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Quality gate (regression baseline — see EXECUTION_STANDARD.md §12)
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: quality-gate-baseline
+quality-gate-baseline: ## Capture the quality-gate baseline after a clean run
+	$(PYTHON) scripts/quality_gate.py baseline
+
+.PHONY: quality-gate-verify
+quality-gate-verify: ## Verify current metrics against the baseline
+	$(PYTHON) scripts/quality_gate.py verify
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Docs (drift-checked)

--- a/Makefile.with-sub-folder
+++ b/Makefile.with-sub-folder
@@ -1,4 +1,5 @@
 #!make
+# makefile-tier: infra   # set for your repo: lib | python-app | fullstack | infra
 ifneq (,)
 	$(error This Makefile requires GNU Make)
 endif
@@ -63,3 +64,38 @@ help: ## Display this help message
 help-%: ## Show detailed help for a specific command
 	@echo "Showing help for: $*"
 	@grep -A 5 -B 2 "^$*:" $(shell find makefiles -name "*.Makefile" -type f) || echo "Command '$*' not found"
+
+# ─── Standard targets (shared-standards EXECUTION_STANDARD.md §1) ──────────────
+# Stubs so a fresh scaffold passes `makefile-check` (which reads only this root
+# file, not the included makefiles/). Move each into the matching
+# makefiles/<category>.Makefile and delete it here as you wire the real command.
+
+install: ## Install dependencies
+	@echo "TODO: install dependencies"
+
+lint: ## Run linter
+	@echo "TODO: run linter"
+
+format: ## Auto-format code
+	@echo "TODO: format code"
+
+typecheck: ## Run static type checker
+	@echo "TODO: typecheck"
+
+test: ## Run unit tests
+	@echo "TODO: run tests"
+
+test-cov: ## Run tests with coverage (writes coverage.xml)
+	@echo "TODO: run tests with coverage"
+
+build: ## Build production artefact
+	@echo "TODO: build"
+
+dev: ## Start dev server / watch mode
+	@echo "TODO: dev"
+
+clean: ## Remove generated artefacts and caches
+	@echo "TODO: clean"
+
+pre-commit: ## Run pre-commit hooks on all files
+	@pre-commit run --all-files


### PR DESCRIPTION
## Why
No released/`main` ref of base-makefile passed its own §1 gate (`makefile-check` in chrysa/pre-commit-tools): the templates lacked the `# makefile-tier:` marker and the tier's required targets, so any fresh scaffold failed the gate. The conformant `Makefile.python` was stranded on the unmerged `feat/docs-drift-targets` branch.

This blocks the new fleet sync tooling in **chrysa/shared-standards#102**, which scaffolds repos from these templates.

## What
- **Makefile.python** — conformant python-app target set (`dev`, `test-cov`, `typecheck`, `docker-up/down`, `ci`). Passes `python-app`, `lib`, `fullstack`.
- **Makefile.basic / Makefile.with-sub-folder** — add `# makefile-tier: infra` marker + stub core targets (`install/lint/format/typecheck/test/test-cov/build/dev/clean/pre-commit`, `@`-prefixed, `## ` help). Passes `infra` and `lib`. TODO stubs filled per stack; with-sub-folder notes moving them into `makefiles/`.

## Verified
All three gate-checked via `makefile_check.py` at every tier they map to — PASS (python-app, lib, infra). The repo's own `Makefile` is untouched.

## Follow-up
After merge, cut a release tag and pin `BASE_MAKEFILE_REF` in shared-standards `scripts/sync-makefile.sh` to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)