### PR TITLE
chore(pre-commit): bump pre-commit-tools to v0.1.1-97

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,4 @@ repos:
   - id: json-sorter
   - id: env-file-check
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-72
+  rev: v0.1.1-97


### PR DESCRIPTION
Bump chrysa/pre-commit-tools v0.1.1-72 → v0.1.1-97. Activates the pattern-detection engine fix (#268): subscribed detection hooks now actually scan on commit. pre-commit runs on changed files only, so existing tree is unaffected.