### PR TITLE
chore(pre-commit): add shellcheck for shell scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,12 @@ repos:
   repo: https://github.com/Yelp/detect-secrets
   rev: v1.5.0
 - hooks:
+  - id: shellcheck
+    args:
+    - --severity=warning
+  repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.10.0.1
+- hooks:
   - exclude: ^\.github/workflows/|^GitVersion\.yml$
     id: yaml-sorter
   - id: json-sorter


### PR DESCRIPTION
Ajoute le hook **shellcheck** (severity=warning) — le repo livre des scripts shell (`scripts/smoke-test.sh`) sans linter shell. Passe vert sur le script existant.

checkmake (lint Makefile) écarté volontairement : trop de faux positifs sur des Makefiles *templates* (exige des cibles all/test) + dépend d'un binaire Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)